### PR TITLE
Fixed #61 Not able to view order in Backend

### DIFF
--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -9,7 +9,7 @@
     <body>
        <referenceContainer name="left">
          <referenceContainer name="payment_additional_info">
-            <block class="Knawat\Dropshipping\Block\Adminhtml\Orderview" name="knawat.sales.order.view"  template="Knawat_Dropshipping::order/knawatShipment.phtml" />
+            <block class="Knawat\Dropshipping\Block\Adminhtml\OrderView" name="knawat.sales.order.view"  template="Knawat_Dropshipping::order/knawatShipment.phtml" />
         </referenceContainer>
     </referenceContainer>
 </body>


### PR DESCRIPTION
Fixed #61 Not able to view order in Backend

**Preconditions**

1. Order must be created for Knawat product

**Steps to reproduce**
    

1. Create a order belonging to Knawat product from frontend.
2. Now logged in to backend and navigate to Sales -> Order
3. Open the newly created order in previous steps
4. You will get the error: Exception occurred during order load


**Expected result**
You will able to view the order without any errors

**Actual result**
Exception occurred during order load