### PR TITLE
improved product sync

### DIFF
--- a/Helper/BackgroundImport.php
+++ b/Helper/BackgroundImport.php
@@ -106,12 +106,6 @@ class BackgroundImport extends \Knawat\Dropshipping\Helper\BackgroundProcess
         }
         if($params['last_updated']){
             $date = $params['last_updated'];
-            if (strpos($date, 'T') !== false) {
-                $date = str_replace('T', ' ', $date);
-            }
-            if (strpos($date, 'Z') !== false) {
-                $date = str_replace('Z', '', $date);
-            }
             $datetime = new \DateTime($date);
 			$lastUpdateTime = (int) ($datetime->getTimestamp().$datetime->format('u')/ 1000);
             $lastImportPath = parent::PATH_KNAWAT_DEFAULT.'knawat_last_imported';

--- a/Helper/BackgroundImport.php
+++ b/Helper/BackgroundImport.php
@@ -104,12 +104,15 @@ class BackgroundImport extends \Knawat\Dropshipping\Helper\BackgroundProcess
              $lastImportedCount = parent::PATH_KNAWAT_DEFAULT.'knawat_last_imported_count';
             $this->setConfig($lastImportedCount, $params['products_total']);
         }
-        if($params['last_updated']){
+         if(array_key_exists('last_updated',$params)){
             $date = $params['last_updated'];
             $datetime = new \DateTime($date);
-			$lastUpdateTime = (int) ($datetime->getTimestamp().$datetime->format('u')/ 1000);
+            $lastUpdateTime = (int) ($datetime->getTimestamp().$datetime->format('u')/ 1000);
             $lastImportPath = parent::PATH_KNAWAT_DEFAULT.'knawat_last_imported';
             $this->setConfig($lastImportPath, $lastUpdateTime);
+            $item['page']  = 1;
+        }else{
+            $item['page']  += 1;
         }
         if ($params['is_complete']) {
             // Send success.

--- a/Helper/BackgroundImport.php
+++ b/Helper/BackgroundImport.php
@@ -112,12 +112,8 @@ class BackgroundImport extends \Knawat\Dropshipping\Helper\BackgroundProcess
             if (strpos($date, 'Z') !== false) {
                 $date = str_replace('Z', '', $date);
             }
-            $date = $this->timezone->date(new \DateTime($date))->format('Y-m-d H:i:s.u');
-            $useconds = $this->timezone->date(new \DateTime($date))->format('u');
-            $timeStamp = strtotime($date);
-            $ts_micro = (float) ($timeStamp . '.' . $useconds);
-            $ts_mili = (float) ($ts_micro * 1000);
-            $lastUpdateTime = round($ts_mili);
+            $datetime = new \DateTime($date);
+			$lastUpdateTime = (int) ($datetime->getTimestamp().$datetime->format('u')/ 1000);
             $lastImportPath = parent::PATH_KNAWAT_DEFAULT.'knawat_last_imported';
             $this->setConfig($lastImportPath, $lastUpdateTime);
         }

--- a/Helper/BackgroundImport.php
+++ b/Helper/BackgroundImport.php
@@ -131,7 +131,7 @@ class BackgroundImport extends \Knawat\Dropshipping\Helper\BackgroundProcess
                 $item['product_index']  = -1;
             } else {
                 $item['page']  = $params['page'];
-                $item['product_index']  = $params['product_index'];
+                $item['product_index']  = -1;
             }
             $item['imported'] += count($results['imported']);
             $item['failed']   += count($results['failed']);

--- a/Helper/BackgroundImport.php
+++ b/Helper/BackgroundImport.php
@@ -125,7 +125,6 @@ class BackgroundImport extends \Knawat\Dropshipping\Helper\BackgroundProcess
         } else {
             $item = $params;
             if ($params['products_total'] == ($params['product_index'] + 1)) {
-                $item['page']  = $params['page'] + 1;
                 $item['product_index']  = -1;
             } else {
                 $item['page']  = $params['page'];

--- a/Helper/ProductImport.php
+++ b/Helper/ProductImport.php
@@ -309,7 +309,7 @@ class ProductImport extends \Magento\Framework\App\Helper\AbstractHelper
                         $totalQty += isset($vars['stock_quantity']) ? $vars['stock_quantity'] : 0;
                     }
                 }
-                if(isset($formated_data['updated_time'])){
+                if(!empty($formated_data['updated_time'])){
                     $this->params['last_updated'] = $formated_data['updated_time'];
                 }
 
@@ -694,7 +694,7 @@ class ProductImport extends \Magento\Framework\App\Helper\AbstractHelper
 
             $sku = $product->sku;
             $updated = $product->updated;
-            if($updated){
+            if(isset($updated)){
                 $new_product['updated_time'] = $updated;
             }
             $product_id = $this->getProductBySku($sku);

--- a/Helper/ProductImport.php
+++ b/Helper/ProductImport.php
@@ -235,10 +235,13 @@ class ProductImport extends \Magento\Framework\App\Helper\AbstractHelper
         switch ($this->importType) {
             case 'full':
                 $lastUpdated = $this->generalHelper->getConfigDirect('knawat_last_imported', true);
-                if (empty($lastUpdated) || (isset($this->params['is_manual']) && $this->params['is_manual'] == 'true')) {
+                $sortData = array(
+                  'sort' => array('field'=>'updated','order'=>'asc')
+                );
+                if (empty($lastUpdated)) {
                     $lastUpdated = 0;
                 }
-                $this->data = $mp->getProducts($this->params['limit'], $this->params['page'], $lastUpdated);
+                $this->data = $mp->getProducts($this->params['limit'], $this->params['page'], $lastUpdated,$sortData);
                 break;
 
             case 'single':
@@ -305,6 +308,9 @@ class ProductImport extends \Magento\Framework\App\Helper\AbstractHelper
                     foreach ($variations as $vars) {
                         $totalQty += isset($vars['stock_quantity']) ? $vars['stock_quantity'] : 0;
                     }
+                }
+                if(isset($formated_data['updated_time'])){
+                    $this->params['last_updated'] = $formated_data['updated_time'];
                 }
 
                 if (!isset($formated_data['id']) || empty($formated_data['id'])) {
@@ -687,6 +693,10 @@ class ProductImport extends \Magento\Framework\App\Helper\AbstractHelper
             $attributes = [];
 
             $sku = $product->sku;
+            $updated = $product->updated;
+            if($updated){
+                $new_product['updated_time'] = $updated;
+            }
             $product_id = $this->getProductBySku($sku);
             if ($product_id) {
                 $new_product['id'] = $product_id;


### PR DESCRIPTION
## :memo: Description
- Products will be now updated with lastupdated time in miliseconds and in ascending sortorder as well it will start new batch based on lastimport time for automatic and manual import

- Last updated time will be saved in database 'core_config_data' table with path 'knawat/store/knawat_last_imported' and it will store data in miliseconds
- Last updated product count at above time will be saved in 'core_config_data' table with path 'knawat/store/knawat_last_imported_count'
- We have added time of last product in batch with above key and its count in database to continue next import based on lastimport time  

### :dart: Relevant issues
https://github.com/Knawat/knawat-dropshipping-magento2/issues/76#issue-734462535
https://github.com/Knawat/knawat-dropshipping-magento2/issues/68#issue-722213846

### :gem: Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### :scroll: Steps to test
1. Please start import with this latest code
2. If product has lastimport time (you can verify with 'core_config_data' table with path 'knawat/store/knawat_last_imported') then it will start import from that time and will continue adding products 
3. If product has no lastimport time then it will start from begning and when process completed/stops it will save last import time and count in database 
4. Lastimport time should be updated in miliseconds for every batch , as well count should be updated for products ('core_config_data' table with path 'knawat/store/knawat_last_imported_count')
5. For verification you can check API call and data with lastimported params with postman , lastimported params will be taken from database with mentioned path and table in description
